### PR TITLE
Initial version with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,40 @@
 # js-ipld-url-resolve
 Resolver for IPLD URLs based on the js-IPFS DAG API. supports advanced features like schemas and escaping
+
+## Features:
+
+- Traverse IPLD URLs
+- Support special character escaping in path segments (e.g. '/')
+- Support for IPLD URL path segment parameter syntax `using ;`
+- Support IPLD Schemas as lenses during traversal
+- ADL Registry for `schema` parameter to convert nodes
+
+## API
+
+```javascript
+import IPLDURLSystem from 'js-ipld-url-resolve'
+
+// You map provide an optional map of ADLs to use
+const adls = new Map()
+
+// This ADL will asynchronously stringify any data into a JSON string
+// It's kinda useless, but you can make ADLs that return any JS object
+// Whose properties can be getters that reuturn Promises that will get
+// Automatically awaited during traversal.
+// The `parameters` are the IPLDURL parameters for that node's segment
+// Parameters might also be coming from the querystring if it's the root
+adls.set('example', async (node, parameters, system) => JSON.stringify(node))
+
+async function getNode(cid) {
+    const {value} = ipfs.dag.get(cid)
+    return value
+}
+
+const system = new IPLDURLSystem({
+  getNode,
+  adls
+})
+
+// Resolve some data from an IPLD URL
+const data = await system.resolve('ipld://some_cid/some_path;schema=schema_cid;type=SchemaTypeName/plainpath/?adl=example')
+```

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ Resolver for IPLD URLs based on the js-IPFS DAG API. supports advanced features 
 - Support special character escaping in path segments (e.g. '/')
 - Support for IPLD URL path segment parameter syntax `using ;`
 - Support IPLD Schemas as lenses during traversal
+- Resolve Links during traversal of schemas
+	- [x] Struct fields
+	- [x] Map values
+	- [x] List values
+	- [ ] Union types
+	- [ ] Links deeply nested within structs/maps
 - ADL Registry for `schema` parameter to convert nodes
 
 ## API

--- a/index.js
+++ b/index.js
@@ -1,0 +1,130 @@
+import { IPLDURL } from 'js-ipld-url'
+import { create as createTyped } from '@ipld/schema/typed.js'
+import { toDSL } from '@ipld/schema/to-dsl.js'
+import { CID } from 'multiformats/cid'
+import { base32 } from 'multiformats/bases/base32'
+import { base36 } from 'multiformats/bases/base36'
+
+export const DEFAULT_CID_BASES = base32.decoder.or(base36.decoder)
+
+export default class IPLDURLSystem {
+  constructor ({
+    getNode,
+    adls = new Map(),
+    cidBases = DEFAULT_CID_BASES
+  }) {
+    if(!getNode) throw new TypeError('Must provide a getNode function')
+    this.getNode = getNode
+    this.adls = adls
+    this.cidBases = cidBases
+  }
+
+  async resolve (url) {
+    const { hostname: root, segments, searchParams } = new IPLDURL(url)
+
+    const cid = CID.parse(root, this.cidBases).toV1()
+    let data = await this.getNode(cid)
+
+    const initialParameters = {}
+    let shouldProcessRoot = false
+    if (searchParams.has('schema')) {
+      shouldProcessRoot = true
+      initialParameters.schema = searchParams.get('schema')
+      initialParameters.type = searchParams.get('type')
+    }
+    if (searchParams.has('adl')) {
+      // TODO Should other parameters be passed to the ADL function?
+      shouldProcessRoot = true
+      initialParameters.adl = searchParams.get('adl')
+    }
+    if (shouldProcessRoot) {
+      data = await this.#applyParameters(data, initialParameters)
+    }
+
+    // TODO: Account for dag-pb?
+    for (const { name, parameters } of segments) {
+      // This does enables ADLs to return promises for properties
+      data = await data[name]
+      const asCID = CID.asCID(data)
+      if (asCID) {
+        data = await this.getNode(asCID)
+      }
+      data = await this.#applyParameters(data, parameters)
+    }
+
+    return data
+  }
+
+  async #applyParameters (origin, { schema, adl, ...parameters }) {
+    let data = origin
+
+    const asCID = CID.asCID(data)
+    if (asCID) {
+      data = await this.getNode(asCID)
+    }
+
+    if (schema) {
+      data = await SchemaADL(data, { schema, ...parameters }, this)
+    }
+
+    if (adl) {
+      if (!this.adls.has(adl)) {
+        const known = [...this.adls.keys()].join(', ')
+        throw new Error(`Unknown ADL type ${adl}. Must be one of ${known}`)
+      }
+      data = await this.adls.get(adl)(data, parameters, this)
+    }
+
+    return data
+  }
+}
+
+export async function SchemaADL (node, { schema, type }, system) {
+  if (!schema || !type) {
+    throw new TypeError('Must specify which type to use with the schema parameter')
+  }
+
+  const schemaCID = CID.parse(schema, system.cidBases)
+  const schemaDMT = await system.getNode(schemaCID)
+  const converted = makeTyped(node, schemaDMT, type)
+
+  const typeDMT = schemaDMT.types[type]
+
+  const typedFields = new Map()
+  if (typeDMT.struct) {
+    for (const [name, fieldDMT] of Object.entries(typeDMT.struct.fields)) {
+      const nestedType = fieldDMT.type?.link?.expectedType
+      typedFields.set(name, nestedType)
+    }
+  }
+
+  if (typedFields.size) {
+    const trapped = new Proxy(converted, {
+      async get (target, property) {
+        const value = target[property]
+        if (!typedFields.has(property)) return value
+        const asCID = CID.asCID(value)
+        if (!asCID) return value
+        // Resolve the CID to the Node
+        const resolved = await system.getNode(asCID)
+        return makeTyped(resolved, schemaDMT, typedFields.get(property))
+      }
+    })
+    return trapped
+  }
+
+  // TODO: Add a trap to convert linked properties to their type, if there are subfields that are links
+
+  return converted
+}
+
+export function makeTyped (node, schemaDMT, type) {
+  const typedSchema = createTyped(schemaDMT, type)
+  const converted = typedSchema.toTyped(node)
+  if (!converted) {
+    const dataView = JSON.stringify(node)
+    const schemaDSL = toDSL(schemaDMT)
+    throw new Error(`Data did not match schema\nData: ${dataView}\nSchema:${schemaDSL}`)
+  }
+  return converted
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/RangerMauve/js-ipld-url-resolve#readme",
   "dependencies": {
+    "@ipld/printify": "^0.1.0",
     "@ipld/schema": "^4.1.0",
     "js-ipld-url": "^1.0.2",
     "multiformats": "^9.7.1"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "js-ipld-url-resolve",
+  "version": "1.0.0",
+  "description": "Resolver for IPLD URLs based on the js-IPFS DAG API. supports advanced features like schemas and escaping",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "test": "node test.js",
+    "lint": "standard --fix"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/RangerMauve/js-ipld-url-resolve.git"
+  },
+  "keywords": [
+    "ipld",
+    "url",
+    "resolve"
+  ],
+  "author": "rangermauve <ranger@mauve.moe> (https://mauve.moe/)",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/RangerMauve/js-ipld-url-resolve/issues"
+  },
+  "homepage": "https://github.com/RangerMauve/js-ipld-url-resolve#readme",
+  "dependencies": {
+    "@ipld/schema": "^4.1.0",
+    "js-ipld-url": "^1.0.2",
+    "multiformats": "^9.7.1"
+  },
+  "devDependencies": {
+    "ipfs-core": "^0.16.0",
+    "standard": "^17.0.0",
+    "tape": "^5.6.0"
+  }
+}

--- a/test.js
+++ b/test.js
@@ -1,0 +1,182 @@
+import IPLDURLSystem from './index.js'
+
+import { create } from 'ipfs-core'
+import { fromDSL } from '@ipld/schema/from-dsl.js'
+
+import test from 'tape'
+
+const node = await create({
+  silent: true,
+  config: {
+    Bootstrap: []
+  },
+  libp2p: {
+    nat: {
+      enabled: false
+    }
+  }
+})
+
+test.onFinish(() => {
+  node.stop()
+})
+
+test('Load simple value from URL', async (t) => {
+  const system = new IPLDURLSystem({ getNode })
+  const cid = await put({ hello: 'world' })
+  const url = `ipld://${cid}/hello`
+
+  const resolved = await system.resolve(url)
+
+  t.equal(resolved, 'world', 'resolved expected value')
+})
+
+test('Interpret root data via schema type', async (t) => {
+  const system = new IPLDURLSystem({ getNode })
+  const schemaCID = await addSchema(`
+    type Example {String:String} representation listpairs
+  `)
+  const dataCID = await put([
+    ['Hello', 'World'],
+    ['Goodbye', 'Cyberspace']
+  ])
+  const url = `ipld://${dataCID}/?schema=${schemaCID}&type=Example`
+
+  const resolved = await system.resolve(url)
+
+  t.deepEqual(resolved, {
+    Hello: 'World',
+    Goodbye: 'Cyberspace'
+  }, 'Parsed data into expected structure')
+})
+
+test('Interpret nested data via schema type', async (t) => {
+  const system = new IPLDURLSystem({ getNode })
+  const schemaCID = await addSchema(`
+    type Example {String:String} representation listpairs
+  `)
+  const dataCID = await put({
+    example: [
+      ['Hello', 'World'],
+      ['Goodbye', 'Cyberspace']
+    ]
+  })
+  const url = `ipld://${dataCID}/example;schema=${schemaCID};type=Example`
+
+  const resolved = await system.resolve(url)
+
+  t.deepEqual(resolved, {
+    Hello: 'World',
+    Goodbye: 'Cyberspace'
+  }, 'Parsed data into expected structure')
+})
+
+test('Apply schema for sub-nodes during pathing', async (t) => {
+  const system = new IPLDURLSystem({ getNode })
+  const schemaCID = await addSchema(`
+    type Example struct {
+      Hello String
+      Goodbye NestedExample
+    } representation tuple
+    type NestedExample struct {
+      region String
+    } representation tuple
+  `)
+  const dataCID = await put(
+    ['Hello', ['Cyberspace']]
+  )
+
+  const expected = {
+    region: 'Cyberspace'
+  }
+  const url = `ipld://${dataCID}/Goodbye?schema=${schemaCID}&type=Example`
+
+  const resolved = await system.resolve(url)
+
+  t.deepEqual(resolved, expected, 'Parsed data into expected structure')
+})
+
+test('Traverse over links', async (t) => {
+  const system = new IPLDURLSystem({ getNode })
+
+  const cid1 = await put('Hello, World?')
+  const cid2 = await put({
+    example: cid1
+  })
+
+  const rootURL = `ipld://${cid2}/`
+
+  const expected1 = {
+    example: cid1
+  }
+
+  const resolved1 = await system.resolve(rootURL)
+
+  t.deepEqual(resolved1, expected1, 'Resolved data with CID present')
+
+  const subURL = rootURL + 'example'
+
+  const expected2 = 'Hello, World?'
+  const resolved2 = await system.resolve(subURL)
+
+  t.deepEqual(resolved2, expected2, 'Resolved data pointed to by link')
+})
+
+test('Preserve schema type when traversing Links', async (t) => {
+  const system = new IPLDURLSystem({ getNode })
+
+  const schemaCID = await addSchema(`
+    type Example struct {
+      Hello String
+      Goodbye &NestedExample
+    } representation tuple
+    type NestedExample struct {
+      region String
+    } representation tuple
+  `)
+
+  const cid1 = await put(['Cyberspace'])
+  const cid2 = await put(['Hello', cid1])
+
+  const expected = {
+    region: 'Cyberspace'
+  }
+  const url = `ipld://${cid2}/Goodbye?schema=${schemaCID}&type=Example`
+
+  const resolved = await system.resolve(url)
+
+  t.deepEqual(resolved, expected, 'Parsed data into expected structure')
+})
+
+test('Traverse segments with / in the name', async (t) => {
+  const system = new IPLDURLSystem({ getNode })
+
+  const weirdPath = "hello/world"
+  const cid = await put({
+    [weirdPath]: "Fancy!"
+  })
+
+  const url = `ipld://${cid}/${encodeURIComponent(weirdPath)}/`
+
+  const resolved = await system.resolve(url)
+
+  t.equal(resolved, 'Fancy!', 'Resolved data at nested path')
+})
+
+async function addSchema (dslString) {
+  // Convert to DMT
+  const dmt = fromDSL(dslString)
+  // Add to IPFS node
+  const cid = put(dmt)
+  // Return CID
+  return cid
+}
+
+async function put (data) {
+  return node.dag.put(data)
+}
+
+async function getNode (cid) {
+  const { value } = await node.dag.get(cid)
+  return value
+}

--- a/test.js
+++ b/test.js
@@ -151,9 +151,9 @@ test('Preserve schema type when traversing Links', async (t) => {
 test('Traverse segments with / in the name', async (t) => {
   const system = new IPLDURLSystem({ getNode })
 
-  const weirdPath = "hello/world"
+  const weirdPath = 'hello/world'
   const cid = await put({
-    [weirdPath]: "Fancy!"
+    [weirdPath]: 'Fancy!'
   })
 
   const url = `ipld://${cid}/${encodeURIComponent(weirdPath)}/`


### PR DESCRIPTION
Got support for IPLD URL parsing, traversal accross links and escaped paths, support for ADLs which can asynchronously load paths, support for schemas and using schemas as sort of ADL.

TODO:

- [ ] Add JSDoc types
- [ ] Support all places where typed links could exist in the data model
  - [ ] lists of links
  - [ ] maps with links
  - [ ] ???
- [ ] Change wording from "ADL" to "Lenses" with ADLs being a subset of Lenses.
- [ ] Add tests for 'failing' resolves for Schemas
- [ ] Add test for a basic ADL
- [ ] Integrate Aegir and prep move to IPLD GH org.